### PR TITLE
refactor(dialog): MatDialog to ZardDialogService across the app (Phase 4a)

### DIFF
--- a/src/app/app-modules/core/components/app-header/app-header.component.ts
+++ b/src/app/app-modules/core/components/app-header/app-header.component.ts
@@ -24,7 +24,7 @@ import { Router, RouterLink, RouterLinkActive } from '@angular/router';
 import { AuthService } from '../../services/auth.service';
 import { ConfirmationService } from '../../services/confirmation.service';
 import { LanguageService } from '../../services/language.service';
-import { MatDialog } from '@angular/material/dialog';
+import { ZardDialogService } from 'Common-UI/v2/ui/dialog';
 import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 import { environment } from 'src/environments/environment';
 import { CookieService } from 'ngx-cookie-service';
@@ -99,7 +99,7 @@ export class AppHeaderComponent implements OnInit, OnChanges {
   constructor(
     private router: Router,
     private auth: AuthService,
-    private dialog: MatDialog,
+    private dialog: ZardDialogService,
     private http_service: LanguageService,
     readonly sessionstorage: SessionStorageService,
     private confirmationService: ConfirmationService,
@@ -383,8 +383,14 @@ export class AppHeaderComponent implements OnInit, OnChanges {
     }
   }
   showData(versionData: any) {
-    const dialogRef = this.dialog.open(ShowCommitAndVersionDetailsComponent, {
-      data: versionData,
+    const dialogRef = this.dialog.create<
+      ShowCommitAndVersionDetailsComponent,
+      unknown
+    >({
+      zContent: ShowCommitAndVersionDetailsComponent,
+      zData: versionData,
+      zHideFooter: true,
+      zClosable: false,
     });
   }
 

--- a/src/app/app-modules/core/components/batch-adjustment/batch-adjustment.component.ts
+++ b/src/app/app-modules/core/components/batch-adjustment/batch-adjustment.component.ts
@@ -26,7 +26,7 @@ import { ConfirmationService } from '../../services/confirmation.service';
 import { Observable } from 'rxjs';
 import { SetLanguageComponent } from '../set-language.component';
 import { LanguageService } from '../../services/language.service';
-import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { Z_MODAL_DATA, ZardDialogRef } from 'Common-UI/v2/ui/dialog';
 import { MatTableDataSource } from '@angular/material/table';
 import { MatPaginator } from '@angular/material/paginator';
 import { FormsModule } from '@angular/forms';
@@ -74,9 +74,9 @@ export class BatchAdjustmentComponent implements OnInit, DoCheck {
   data: any;
 
   constructor(
-    @Inject(MAT_DIALOG_DATA) public input: any,
+    @Inject(Z_MODAL_DATA) public input: any,
     private confirmationService: ConfirmationService,
-    public dialogRef: MatDialogRef<BatchAdjustmentComponent>,
+    public dialogRef: ZardDialogRef<BatchAdjustmentComponent>,
     public http_service: LanguageService,
     private batchSearchService: BatchSearchService,
   ) {}

--- a/src/app/app-modules/core/components/batch-search/batch-search.component.ts
+++ b/src/app/app-modules/core/components/batch-search/batch-search.component.ts
@@ -26,7 +26,7 @@ import { ConfirmationService } from '../../services/confirmation.service';
 import { Observable } from 'rxjs';
 import { SetLanguageComponent } from '../set-language.component';
 import { LanguageService } from '../../services/language.service';
-import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { Z_MODAL_DATA, ZardDialogRef } from 'Common-UI/v2/ui/dialog';
 import { MatTableDataSource } from '@angular/material/table';
 import { MatPaginator } from '@angular/material/paginator';
 import { FormsModule } from '@angular/forms';
@@ -73,10 +73,10 @@ export class BatchSearchComponent implements OnInit, DoCheck {
   @ViewChild(MatPaginator) paginator: MatPaginator | null = null;
 
   constructor(
-    @Inject(MAT_DIALOG_DATA) public input: any,
+    @Inject(Z_MODAL_DATA) public input: any,
     private confirmationService: ConfirmationService,
     public http_service: LanguageService,
-    public dialogRef: MatDialogRef<BatchSearchComponent>,
+    public dialogRef: ZardDialogRef<BatchSearchComponent>,
     private batchSearchService: BatchSearchService,
   ) {}
 

--- a/src/app/app-modules/core/components/common-dialog/common-dialog.component.ts
+++ b/src/app/app-modules/core/components/common-dialog/common-dialog.component.ts
@@ -28,7 +28,7 @@ import {
 } from '@angular/core';
 import { LanguageService } from '../../services/language.service';
 import { SetLanguageComponent } from '../set-language.component';
-import { MatDialogRef } from '@angular/material/dialog';
+import { ZardDialogRef } from 'Common-UI/v2/ui/dialog';
 import {
   NgIf,
   NgClass,
@@ -104,7 +104,7 @@ export class CommonDialogComponent implements OnInit {
   currentLanguageSet: any;
 
   constructor(
-    public dialogRef: MatDialogRef<CommonDialogComponent>,
+    public dialogRef: ZardDialogRef<CommonDialogComponent>,
     public http_service: LanguageService,
   ) {}
 

--- a/src/app/app-modules/core/components/indent-item-list/indent-item-list.component.ts
+++ b/src/app/app-modules/core/components/indent-item-list/indent-item-list.component.ts
@@ -25,7 +25,7 @@ import { Observable } from 'rxjs';
 import { BatchSearchService } from '../../services/batch-search.service';
 import { SetLanguageComponent } from '../set-language.component';
 import { LanguageService } from '../../services/language.service';
-import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { Z_MODAL_DATA, ZardDialogRef } from 'Common-UI/v2/ui/dialog';
 import { MatTableDataSource } from '@angular/material/table';
 import { MatPaginator } from '@angular/material/paginator';
 import { FormsModule } from '@angular/forms';
@@ -81,9 +81,9 @@ export class IndentItemListComponent implements OnInit, DoCheck {
   ];
 
   constructor(
-    @Inject(MAT_DIALOG_DATA) public input: any,
+    @Inject(Z_MODAL_DATA) public input: any,
     private confirmationService: ConfirmationService,
-    public dialogRef: MatDialogRef<IndentItemListComponent>,
+    public dialogRef: ZardDialogRef<IndentItemListComponent>,
     public http_service: LanguageService,
     private batchSearchService: BatchSearchService,
   ) {}

--- a/src/app/app-modules/core/components/item-dispense/item-dispense.component.ts
+++ b/src/app/app-modules/core/components/item-dispense/item-dispense.component.ts
@@ -26,7 +26,7 @@ import { ConfirmationService } from '../../services/confirmation.service';
 import { Observable } from 'rxjs';
 import { SetLanguageComponent } from '../set-language.component';
 import { LanguageService } from '../../services/language.service';
-import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { Z_MODAL_DATA, ZardDialogRef } from 'Common-UI/v2/ui/dialog';
 import { MatTableDataSource } from '@angular/material/table';
 import { MatPaginator } from '@angular/material/paginator';
 import { FormsModule } from '@angular/forms';
@@ -71,10 +71,10 @@ export class ItemDispenseComponent implements OnInit, DoCheck {
   @ViewChild(MatPaginator) paginator: MatPaginator | null = null;
 
   constructor(
-    @Inject(MAT_DIALOG_DATA) public input: any,
+    @Inject(Z_MODAL_DATA) public input: any,
     private itemSearchService: ItemSearchService,
     public http_service: LanguageService,
-    public dialogRef: MatDialogRef<ItemDispenseComponent>,
+    public dialogRef: ZardDialogRef<ItemDispenseComponent>,
     private confirmationService: ConfirmationService,
   ) {}
 

--- a/src/app/app-modules/core/components/item-search/item-search.component.ts
+++ b/src/app/app-modules/core/components/item-search/item-search.component.ts
@@ -25,7 +25,7 @@ import { ItemSearchService } from '../../services/item-search.service';
 import { Observable } from 'rxjs';
 import { SetLanguageComponent } from '../set-language.component';
 import { LanguageService } from '../../services/language.service';
-import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { Z_MODAL_DATA, ZardDialogRef } from 'Common-UI/v2/ui/dialog';
 import { MatTableDataSource } from '@angular/material/table';
 import { MatPaginator } from '@angular/material/paginator';
 import { FormsModule } from '@angular/forms';
@@ -78,9 +78,9 @@ export class ItemSearchComponent implements OnInit, DoCheck {
   ];
 
   constructor(
-    @Inject(MAT_DIALOG_DATA) public input: any,
+    @Inject(Z_MODAL_DATA) public input: any,
     public http_service: LanguageService,
-    public dialogRef: MatDialogRef<ItemSearchComponent>,
+    public dialogRef: ZardDialogRef<ItemSearchComponent>,
     private itemSearchService: ItemSearchService,
   ) {}
 

--- a/src/app/app-modules/core/components/rx-batch-view/rx-batch-view.component.ts
+++ b/src/app/app-modules/core/components/rx-batch-view/rx-batch-view.component.ts
@@ -32,7 +32,7 @@ import {
 import { ConfirmationService } from './../../services/confirmation.service';
 import { LanguageService } from '../../services/language.service';
 import { SetLanguageComponent } from '../set-language.component';
-import { MatDialogRef } from '@angular/material/dialog';
+import { ZardDialogRef } from 'Common-UI/v2/ui/dialog';
 import { DatePipe, NgIf, NgFor, NgClass } from '@angular/common';
 import { StringValidatorDirective } from '../../directives/stringValidator.directive';
 import { ZardButtonComponent } from 'Common-UI/v2/ui/button';
@@ -67,7 +67,7 @@ export class RxBatchViewComponent implements OnInit, DoCheck {
   constructor(
     private fb: FormBuilder,
     private confirmationService: ConfirmationService,
-    public dialogRef: MatDialogRef<RxBatchViewComponent>,
+    public dialogRef: ZardDialogRef<RxBatchViewComponent>,
     private http_service: LanguageService,
   ) {}
   ngOnInit() {

--- a/src/app/app-modules/core/components/search/search.component.ts
+++ b/src/app/app-modules/core/components/search/search.component.ts
@@ -32,7 +32,7 @@ import { InventoryService } from '../../../inventory/shared/service/inventory.se
 import { SetLanguageComponent } from '../set-language.component';
 import { LanguageService } from '../../services/language.service';
 import { environment } from 'src/environments/environment';
-import { MatDialogRef } from '@angular/material/dialog';
+import { ZardDialogRef } from 'Common-UI/v2/ui/dialog';
 import { MatTableDataSource } from '@angular/material/table';
 import { MatPaginator } from '@angular/material/paginator';
 import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
@@ -110,7 +110,7 @@ export class SearchComponent implements OnInit, DoCheck {
 
   constructor(
     private confirmationService: ConfirmationService,
-    public mdDialogRef: MatDialogRef<SearchComponent>,
+    public mdDialogRef: ZardDialogRef<SearchComponent>,
     private commonService: CommonService,
     public http_service: LanguageService,
     private changeDetectorRef: ChangeDetectorRef,

--- a/src/app/app-modules/core/components/show-commit-and-version-details/show-commit-and-version-details.component.ts
+++ b/src/app/app-modules/core/components/show-commit-and-version-details/show-commit-and-version-details.component.ts
@@ -22,7 +22,7 @@
 import { Component, OnInit, Inject, DoCheck } from '@angular/core';
 import { LanguageService } from '../../services/language.service';
 import { SetLanguageComponent } from '../set-language.component';
-import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { Z_MODAL_DATA, ZardDialogRef } from 'Common-UI/v2/ui/dialog';
 import { NgIcon, provideIcons } from '@ng-icons/core';
 import { lucideX } from '@ng-icons/lucide';
 import { ZardButtonComponent } from 'Common-UI/v2/ui/button';
@@ -39,9 +39,9 @@ export class ShowCommitAndVersionDetailsComponent implements OnInit, DoCheck {
   currentLanguageSet: any;
 
   constructor(
-    @Inject(MAT_DIALOG_DATA) public input: any,
+    @Inject(Z_MODAL_DATA) public input: any,
     public http_service: LanguageService,
-    public dialogRef: MatDialogRef<ShowCommitAndVersionDetailsComponent>,
+    public dialogRef: ZardDialogRef<ShowCommitAndVersionDetailsComponent>,
   ) {}
 
   ngOnInit() {

--- a/src/app/app-modules/core/components/textarea-dialog/textarea-dialog.component.ts
+++ b/src/app/app-modules/core/components/textarea-dialog/textarea-dialog.component.ts
@@ -22,7 +22,7 @@
 import { Component, OnInit, Inject, DoCheck } from '@angular/core';
 import { LanguageService } from '../../services/language.service';
 import { SetLanguageComponent } from '../set-language.component';
-import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { Z_MODAL_DATA, ZardDialogRef } from 'Common-UI/v2/ui/dialog';
 import { FormsModule } from '@angular/forms';
 import { ZardInputDirective } from 'Common-UI/v2/ui/input';
 
@@ -36,15 +36,12 @@ export class TextareaDialogComponent implements OnInit, DoCheck {
   currentLanguageSet: any;
 
   constructor(
-    public dialogRef: MatDialogRef<TextareaDialogComponent>,
+    public dialogRef: ZardDialogRef<TextareaDialogComponent>,
     public http_service: LanguageService,
-    @Inject(MAT_DIALOG_DATA) public data: any,
+    @Inject(Z_MODAL_DATA) public data: any,
   ) {}
 
   ngOnInit() {
-    this.dialogRef.backdropClick().subscribe((result) => {
-      this.dialogRef.close(this.data.observations);
-    });
     this.fetchLanguageResponse();
   }
 

--- a/src/app/app-modules/core/components/textarea-dialog/textarea-dialog.service.ts
+++ b/src/app/app-modules/core/components/textarea-dialog/textarea-dialog.service.ts
@@ -21,16 +21,19 @@
  */
 import { Injectable } from '@angular/core';
 import { TextareaDialogComponent } from './textarea-dialog.component';
-import { MatDialog } from '@angular/material/dialog';
+import { ZardDialogService } from 'Common-UI/v2/ui/dialog';
 import { Observable } from 'rxjs';
 @Injectable()
 export class TextareaDialog {
-  constructor(public dialog: MatDialog) {}
+  constructor(public dialog: ZardDialogService) {}
 
   open(observations: string, length = 500): Observable<any> {
-    const dialogRef = this.dialog.open(TextareaDialogComponent, {
-      width: '500px',
-      data: { observations: observations, length: length },
+    const dialogRef = this.dialog.create<TextareaDialogComponent, unknown>({
+      zContent: TextareaDialogComponent,
+      zData: { observations: observations, length: length },
+      zWidth: '500px',
+      zHideFooter: true,
+      zClosable: false,
     });
     return dialogRef.afterClosed();
   }

--- a/src/app/app-modules/core/components/transfer-search/transfer-search.component.ts
+++ b/src/app/app-modules/core/components/transfer-search/transfer-search.component.ts
@@ -24,7 +24,7 @@ import { ItemSearchService } from '../../services/item-search.service';
 import { Observable } from 'rxjs';
 import { SetLanguageComponent } from '../set-language.component';
 import { LanguageService } from '../../services/language.service';
-import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { Z_MODAL_DATA, ZardDialogRef } from 'Common-UI/v2/ui/dialog';
 import { MatTableDataSource } from '@angular/material/table';
 import { MatPaginator } from '@angular/material/paginator';
 import { FormsModule } from '@angular/forms';
@@ -81,8 +81,8 @@ export class TransferSearchComponent implements OnInit, DoCheck {
   ];
 
   constructor(
-    @Inject(MAT_DIALOG_DATA) public input: any,
-    public dialogRef: MatDialogRef<TransferSearchComponent>,
+    @Inject(Z_MODAL_DATA) public input: any,
+    public dialogRef: ZardDialogRef<TransferSearchComponent>,
     public http_service: LanguageService,
     private itemSearchService: ItemSearchService,
   ) {}

--- a/src/app/app-modules/core/directives/batch-adjustment.directive.ts
+++ b/src/app/app-modules/core/directives/batch-adjustment.directive.ts
@@ -22,7 +22,7 @@
 import { Directive, HostListener, Input, ElementRef } from '@angular/core';
 import { BatchAdjustmentComponent } from '../components/batch-adjustment/batch-adjustment.component';
 import { FormArray, FormBuilder, FormGroup } from '@angular/forms';
-import { MatDialog } from '@angular/material/dialog';
+import { ZardDialogService } from 'Common-UI/v2/ui/dialog';
 import { InventoryService } from '../../inventory/shared/service/inventory.service';
 
 @Directive({ selector: '[appBatchAdjustment]' })
@@ -44,7 +44,7 @@ export class BatchAdjustmentDirective {
   constructor(
     private el: ElementRef,
     private fb: FormBuilder,
-    private dialog: MatDialog,
+    private dialog: ZardDialogService,
     private inventoryService: InventoryService,
   ) {}
 
@@ -52,11 +52,12 @@ export class BatchAdjustmentDirective {
     const searchTerm = this.stockForm.value.itemName;
     console.log('SEACHTEREM', searchTerm);
 
-    const dialogRef = this.dialog.open(BatchAdjustmentComponent, {
-      width: '1200px',
-      height: 'auto',
-      panelClass: 'fit-screen',
-      data: { searchTerm: searchTerm, addedStock: this.previousSelected },
+    const dialogRef = this.dialog.create<BatchAdjustmentComponent, unknown>({
+      zContent: BatchAdjustmentComponent,
+      zData: { searchTerm: searchTerm, addedStock: this.previousSelected },
+      zWidth: '1200px',
+      zHideFooter: true,
+      zClosable: false,
     });
 
     dialogRef.afterClosed().subscribe((result) => {

--- a/src/app/app-modules/core/directives/batch-search.directive.ts
+++ b/src/app/app-modules/core/directives/batch-search.directive.ts
@@ -22,7 +22,7 @@
 import { Directive, HostListener, Input, ElementRef } from '@angular/core';
 
 import { FormArray, FormBuilder, Validators, FormGroup } from '@angular/forms';
-import { MatDialog } from '@angular/material/dialog';
+import { ZardDialogService } from 'Common-UI/v2/ui/dialog';
 import { BatchSearchComponent } from '../components/batch-search/batch-search.component';
 import { InventoryService } from '../../inventory/shared/service/inventory.service';
 
@@ -47,18 +47,19 @@ export class BatchSearchDirective {
   constructor(
     private el: ElementRef,
     private fb: FormBuilder,
-    private dialog: MatDialog,
+    private dialog: ZardDialogService,
     private inventoryService: InventoryService,
   ) {}
 
   openDialog(): void {
     const searchTerm = this.stockForm.value.itemName;
 
-    const dialogRef = this.dialog.open(BatchSearchComponent, {
-      width: '1200px',
-      height: 'auto',
-      panelClass: 'fit-screen',
-      data: { searchTerm: searchTerm, addedStock: this.previousSelected },
+    const dialogRef = this.dialog.create<BatchSearchComponent, unknown>({
+      zContent: BatchSearchComponent,
+      zData: { searchTerm: searchTerm, addedStock: this.previousSelected },
+      zWidth: '1200px',
+      zHideFooter: true,
+      zClosable: false,
     });
 
     dialogRef.afterClosed().subscribe((result) => {

--- a/src/app/app-modules/core/directives/indent-dispense.directive.ts
+++ b/src/app/app-modules/core/directives/indent-dispense.directive.ts
@@ -21,7 +21,7 @@
  */
 import { Directive, HostListener, Input, ElementRef } from '@angular/core';
 import { FormGroup } from '@angular/forms';
-import { MatDialog } from '@angular/material/dialog';
+import { ZardDialogService } from 'Common-UI/v2/ui/dialog';
 
 @Directive({ selector: '[appIndentDispense]' })
 export class IndentDispenseDirective {
@@ -41,7 +41,7 @@ export class IndentDispenseDirective {
 
   constructor(
     private el: ElementRef,
-    private dialog: MatDialog,
+    private dialog: ZardDialogService,
   ) {}
 
   openDialog(): void {

--- a/src/app/app-modules/core/directives/indent-request.directive.ts
+++ b/src/app/app-modules/core/directives/indent-request.directive.ts
@@ -22,7 +22,7 @@
 import { Directive, HostListener, Input, ElementRef } from '@angular/core';
 import { IndentItemListComponent } from '../components/indent-item-list/indent-item-list.component';
 import { FormArray, FormBuilder, Validators, FormGroup } from '@angular/forms';
-import { MatDialog } from '@angular/material/dialog';
+import { ZardDialogService } from 'Common-UI/v2/ui/dialog';
 import { InventoryService } from '../../inventory/shared/service/inventory.service';
 
 @Directive({ selector: '[appIndentRequest]' })
@@ -43,18 +43,19 @@ export class IndentRequestDirective {
   constructor(
     private el: ElementRef,
     private fb: FormBuilder,
-    private dialog: MatDialog,
+    private dialog: ZardDialogService,
     private inventoryService: InventoryService,
   ) {}
 
   openDialog(): void {
     // const searchTerm = this.itemListForm.itemNameView;
     const searchTerm = this.itemListForm.controls['itemNameView'].value;
-    const dialogRef = this.dialog.open(IndentItemListComponent, {
-      width: '1200px',
-      height: 'auto',
-      panelClass: 'fit-screen',
-      data: { searchTerm: searchTerm, addedIndent: this.previousSelected },
+    const dialogRef = this.dialog.create<IndentItemListComponent, unknown>({
+      zContent: IndentItemListComponent,
+      zData: { searchTerm: searchTerm, addedIndent: this.previousSelected },
+      zWidth: '1200px',
+      zHideFooter: true,
+      zClosable: false,
     });
     dialogRef.afterClosed().subscribe((result) => {
       if (result) {

--- a/src/app/app-modules/core/directives/item-dispense.directive.ts
+++ b/src/app/app-modules/core/directives/item-dispense.directive.ts
@@ -30,7 +30,7 @@ import {
 import { NgControl, FormGroup } from '@angular/forms';
 
 import { ItemDispenseComponent } from './../components/item-dispense/item-dispense.component';
-import { MatDialog } from '@angular/material/dialog';
+import { ZardDialogService } from 'Common-UI/v2/ui/dialog';
 
 @Directive({ selector: '[appItemDispense]' })
 export class ItemDispenseDirective {
@@ -50,7 +50,7 @@ export class ItemDispenseDirective {
 
   constructor(
     private el: ElementRef,
-    private dialog: MatDialog,
+    private dialog: ZardDialogService,
   ) {}
 
   openDialog(): void {
@@ -58,11 +58,15 @@ export class ItemDispenseDirective {
 
     console.log(this.stockForm);
 
-    const dialogRef = this.dialog.open(ItemDispenseComponent, {
-      width: '1200px',
-      height: 'auto',
-      panelClass: 'fit-screen',
-      data: { searchTerm: searchTerm, dispenseItemList: this.dispenseItemList },
+    const dialogRef = this.dialog.create<ItemDispenseComponent, unknown>({
+      zContent: ItemDispenseComponent,
+      zData: {
+        searchTerm: searchTerm,
+        dispenseItemList: this.dispenseItemList,
+      },
+      zWidth: '1200px',
+      zHideFooter: true,
+      zClosable: false,
     });
 
     dialogRef.afterClosed().subscribe((result) => {

--- a/src/app/app-modules/core/directives/item-search.directive.ts
+++ b/src/app/app-modules/core/directives/item-search.directive.ts
@@ -21,7 +21,7 @@
  */
 import { Directive, HostListener, Input, ElementRef } from '@angular/core';
 import { FormGroup } from '@angular/forms';
-import { MatDialog } from '@angular/material/dialog';
+import { ZardDialogService } from 'Common-UI/v2/ui/dialog';
 import { ItemSearchComponent } from '../components/item-search/item-search.component';
 
 @Directive({ selector: '[appItemSearch]' })
@@ -39,16 +39,17 @@ export class ItemSearchDirective {
 
   constructor(
     private el: ElementRef,
-    private dialog: MatDialog,
+    private dialog: ZardDialogService,
   ) {}
 
   openDialog(): void {
     const searchTerm = this.stockForm.controls['itemName'].value;
-    const dialogRef = this.dialog.open(ItemSearchComponent, {
-      width: '1200px',
-      height: 'auto',
-      panelClass: 'fit-screen',
-      data: { searchTerm: searchTerm },
+    const dialogRef = this.dialog.create<ItemSearchComponent, unknown>({
+      zContent: ItemSearchComponent,
+      zData: { searchTerm: searchTerm },
+      zWidth: '1200px',
+      zHideFooter: true,
+      zClosable: false,
     });
 
     dialogRef.afterClosed().subscribe((result) => {

--- a/src/app/app-modules/core/directives/item-transfer.directive.ts
+++ b/src/app/app-modules/core/directives/item-transfer.directive.ts
@@ -22,7 +22,7 @@
 import { Directive, HostListener, Input, ElementRef } from '@angular/core';
 import { FormArray, FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { TransferSearchComponent } from '../components/transfer-search/transfer-search.component';
-import { MatDialog } from '@angular/material/dialog';
+import { ZardDialogService } from 'Common-UI/v2/ui/dialog';
 
 @Directive({ selector: '[appItemTransfer]' })
 export class ItemTransferDirective {
@@ -43,7 +43,7 @@ export class ItemTransferDirective {
   constructor(
     private el: ElementRef,
     private fb: FormBuilder,
-    private dialog: MatDialog,
+    private dialog: ZardDialogService,
   ) {}
 
   openDialog(): void {
@@ -51,15 +51,16 @@ export class ItemTransferDirective {
     const transferTo =
       this.stockForm?.parent?.parent?.value.transferTo.facilityID;
 
-    const dialogRef = this.dialog.open(TransferSearchComponent, {
-      width: '1200px',
-      height: 'auto',
-      panelClass: 'fit-screen',
-      data: {
+    const dialogRef = this.dialog.create<TransferSearchComponent, unknown>({
+      zContent: TransferSearchComponent,
+      zData: {
         searchTerm: searchTerm,
         transferTo: transferTo,
         addedStock: this.previousSelected,
       },
+      zWidth: '1200px',
+      zHideFooter: true,
+      zClosable: false,
     });
 
     dialogRef.afterClosed().subscribe((result) => {

--- a/src/app/app-modules/core/services/confirmation.service.ts
+++ b/src/app/app-modules/core/services/confirmation.service.ts
@@ -19,22 +19,36 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
-
 import { CommonDialogComponent } from '../components/common-dialog/common-dialog.component';
 import { Injectable, Inject, DOCUMENT } from '@angular/core';
-import {
-  MatDialog,
-  MatDialogConfig,
-  MatDialogRef,
-} from '@angular/material/dialog';
+import { ZardDialogService, ZardDialogRef } from 'Common-UI/v2/ui/dialog';
 import { Observable } from 'rxjs';
 
 @Injectable()
 export class ConfirmationService {
   constructor(
-    private dialog: MatDialog,
+    private dialog: ZardDialogService,
     @Inject(DOCUMENT) doc: any,
   ) {}
+
+  private createDialog(
+    zWidth: string,
+    zMaskClosable: boolean,
+  ): ZardDialogRef<CommonDialogComponent> {
+    const dialogRef = this.dialog.create<CommonDialogComponent, unknown>({
+      zContent: CommonDialogComponent,
+      zWidth,
+      zMaskClosable,
+      zHideFooter: true,
+      zClosable: false,
+    });
+    const instance = dialogRef.componentInstance!;
+    instance.confirmAlert = false;
+    instance.alert = false;
+    instance.remarks = false;
+    instance.editRemarks = false;
+    return dialogRef;
+  }
 
   public confirm(
     title: string,
@@ -42,22 +56,13 @@ export class ConfirmationService {
     btnOkText = 'OK',
     btnCancelText = 'Cancel',
   ): Observable<boolean> {
-    const config = new MatDialogConfig();
-    const dialogRef: MatDialogRef<CommonDialogComponent> = this.dialog.open(
-      CommonDialogComponent,
-      {
-        width: '420px',
-        disableClose: false,
-      },
-    );
-    dialogRef.componentInstance.title = title;
-    dialogRef.componentInstance.message = message;
-    dialogRef.componentInstance.btnOkText = btnOkText;
-    dialogRef.componentInstance.btnCancelText = btnCancelText;
-    dialogRef.componentInstance.confirmAlert = true;
-    dialogRef.componentInstance.alert = false;
-    dialogRef.componentInstance.remarks = false;
-    dialogRef.componentInstance.editRemarks = false;
+    const dialogRef = this.createDialog('420px', true);
+    const instance = dialogRef.componentInstance!;
+    instance.title = title;
+    instance.message = message;
+    instance.btnOkText = btnOkText;
+    instance.btnCancelText = btnCancelText;
+    instance.confirmAlert = true;
 
     return dialogRef.afterClosed();
   }
@@ -66,18 +71,13 @@ export class ConfirmationService {
     message: string,
     status = 'info',
     btnOkText = 'OK',
-  ): MatDialogRef<CommonDialogComponent> {
-    const config = {
-      width: '420px',
-    };
-    const dialogRef = this.dialog.open(CommonDialogComponent, config);
-    dialogRef.componentInstance.message = message;
-    dialogRef.componentInstance.status = status.toLowerCase();
-    dialogRef.componentInstance.btnOkText = btnOkText;
-    dialogRef.componentInstance.confirmAlert = false;
-    dialogRef.componentInstance.alert = true;
-    dialogRef.componentInstance.remarks = false;
-    dialogRef.componentInstance.editRemarks = false;
+  ): ZardDialogRef<CommonDialogComponent> {
+    const dialogRef = this.createDialog('420px', true);
+    const instance = dialogRef.componentInstance!;
+    instance.message = message;
+    instance.status = status.toLowerCase();
+    instance.btnOkText = btnOkText;
+    instance.alert = true;
     return dialogRef;
   }
 
@@ -88,20 +88,12 @@ export class ConfirmationService {
     btnOkText = 'Submit',
     btnCancelText = 'Cancel',
   ): Observable<any> {
-    const config = {
-      width: '420px',
-    };
-    const dialogRef: MatDialogRef<CommonDialogComponent> = this.dialog.open(
-      CommonDialogComponent,
-      config,
-    );
-    dialogRef.componentInstance.message = message;
-    dialogRef.componentInstance.btnOkText = btnOkText;
-    dialogRef.componentInstance.confirmAlert = false;
-    dialogRef.componentInstance.alert = false;
-    dialogRef.componentInstance.remarks = true;
-    dialogRef.componentInstance.editRemarks = false;
-    dialogRef.componentInstance.btnCancelText = btnCancelText;
+    const dialogRef = this.createDialog('420px', true);
+    const instance = dialogRef.componentInstance!;
+    instance.message = message;
+    instance.btnOkText = btnOkText;
+    instance.remarks = true;
+    instance.btnCancelText = btnCancelText;
 
     return dialogRef.afterClosed();
   }
@@ -114,18 +106,13 @@ export class ConfirmationService {
     btnOkText = 'Submit',
     btnCancelText = 'Cancel',
   ): Observable<any> {
-    const dialogRef: MatDialogRef<CommonDialogComponent> = this.dialog.open(
-      CommonDialogComponent,
-      { width: '60%' },
-    );
-    dialogRef.componentInstance.message = message;
-    dialogRef.componentInstance.btnOkText = btnOkText;
-    dialogRef.componentInstance.confirmAlert = false;
-    dialogRef.componentInstance.alert = false;
-    dialogRef.componentInstance.remarks = false;
-    dialogRef.componentInstance.editRemarks = true;
-    dialogRef.componentInstance.comments = comments;
-    dialogRef.componentInstance.btnCancelText = btnCancelText;
+    const dialogRef = this.createDialog('60%', true);
+    const instance = dialogRef.componentInstance!;
+    instance.message = message;
+    instance.btnOkText = btnOkText;
+    instance.editRemarks = true;
+    instance.comments = comments;
+    instance.btnCancelText = btnCancelText;
 
     return dialogRef.afterClosed();
   }
@@ -137,21 +124,12 @@ export class ConfirmationService {
     messageAlign = 'center',
     btnOkText = 'OK',
   ): Observable<any> {
-    const config = {
-      width: '420px',
-    };
-    const dialogRef: MatDialogRef<CommonDialogComponent> = this.dialog.open(
-      CommonDialogComponent,
-      config,
-    );
-    dialogRef.componentInstance.message = message;
-    dialogRef.componentInstance.btnOkText = btnOkText;
-    dialogRef.componentInstance.confirmAlert = false;
-    dialogRef.componentInstance.alert = false;
-    dialogRef.componentInstance.remarks = false;
-    dialogRef.componentInstance.editRemarks = false;
-    dialogRef.componentInstance.notify = true;
-    dialogRef.componentInstance.mandatories = mandatories;
+    const dialogRef = this.createDialog('420px', true);
+    const instance = dialogRef.componentInstance!;
+    instance.message = message;
+    instance.btnOkText = btnOkText;
+    instance.notify = true;
+    instance.mandatories = mandatories;
     return dialogRef.afterClosed();
   }
 
@@ -163,23 +141,14 @@ export class ConfirmationService {
     btnOkText = 'Confirm',
     btnCancelText = 'Cancel',
   ): Observable<any> {
-    const config = {
-      width: '420px',
-    };
-    const dialogRef: MatDialogRef<CommonDialogComponent> = this.dialog.open(
-      CommonDialogComponent,
-      config,
-    );
-    dialogRef.componentInstance.message = message;
-    dialogRef.componentInstance.btnOkText = btnOkText;
-    dialogRef.componentInstance.btnCancelText = btnCancelText;
-    dialogRef.componentInstance.confirmAlert = false;
-    dialogRef.componentInstance.alert = false;
-    dialogRef.componentInstance.remarks = false;
-    dialogRef.componentInstance.editRemarks = false;
-    dialogRef.componentInstance.notify = false;
-    dialogRef.componentInstance.choice = true;
-    dialogRef.componentInstance.values = values;
+    const dialogRef = this.createDialog('420px', true);
+    const instance = dialogRef.componentInstance!;
+    instance.message = message;
+    instance.btnOkText = btnOkText;
+    instance.btnCancelText = btnCancelText;
+    instance.notify = false;
+    instance.choice = true;
+    instance.values = values;
     return dialogRef.afterClosed();
   }
 
@@ -190,24 +159,15 @@ export class ConfirmationService {
     btnOkText = 'Continue',
     btnCancelText = 'Cancel',
   ): Observable<any> {
-    const config = new MatDialogConfig();
-    const dialogRef: MatDialogRef<CommonDialogComponent> = this.dialog.open(
-      CommonDialogComponent,
-      {
-        width: '420px',
-        disableClose: true,
-      },
-    );
-    dialogRef.componentInstance.title = title;
-    dialogRef.componentInstance.message = message;
-    dialogRef.componentInstance.btnOkText = btnOkText;
-    dialogRef.componentInstance.btnCancelText = btnCancelText;
-    dialogRef.componentInstance.confirmAlert = false;
-    dialogRef.componentInstance.alert = false;
-    dialogRef.componentInstance.remarks = false;
-    dialogRef.componentInstance.editRemarks = false;
-    dialogRef.componentInstance.sessionTimeout = true;
-    dialogRef.componentInstance.updateTimer(timer);
+    const dialogRef = this.createDialog('420px', false);
+    const instance = dialogRef.componentInstance!;
+    instance.title = title;
+    instance.message = message;
+    instance.btnOkText = btnOkText;
+    instance.btnCancelText = btnCancelText;
+    instance.sessionTimeout = true;
+    instance.updateTimer(timer);
+    dialogRef.disableClose = true;
     return dialogRef.afterClosed();
   }
 
@@ -219,15 +179,13 @@ export class ConfirmationService {
     btnOkText = 'Confirm',
     btnCancelText = 'Cancel',
   ): Observable<any> {
-    const dialogRef: MatDialogRef<CommonDialogComponent> = this.dialog.open(
-      CommonDialogComponent,
-      { width: '60%' },
-    );
-    dialogRef.componentInstance.message = message;
-    dialogRef.componentInstance.comments = comments;
-    dialogRef.componentInstance.btnOkText = btnOkText;
-    dialogRef.componentInstance.btnCancelText = btnCancelText;
-    dialogRef.componentInstance.provideDraftDesc = true;
+    const dialogRef = this.createDialog('60%', true);
+    const instance = dialogRef.componentInstance!;
+    instance.message = message;
+    instance.comments = comments;
+    instance.btnOkText = btnOkText;
+    instance.btnCancelText = btnCancelText;
+    instance.provideDraftDesc = true;
     return dialogRef.afterClosed();
   }
 }

--- a/src/app/app-modules/core/services/rx-batchview.service.ts
+++ b/src/app/app-modules/core/services/rx-batchview.service.ts
@@ -19,7 +19,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
-import { MatDialog, MatDialogRef } from '@angular/material/dialog';
+import { ZardDialogService, ZardDialogRef } from 'Common-UI/v2/ui/dialog';
 import { Injectable, ViewContainerRef, Inject, DOCUMENT } from '@angular/core';
 
 import { Observable } from 'rxjs';
@@ -28,21 +28,24 @@ import { RxBatchViewComponent } from '../components/rx-batch-view/rx-batch-view.
 @Injectable()
 export class BatchViewService {
   constructor(
-    private dialog: MatDialog,
+    private dialog: ZardDialogService,
     @Inject(DOCUMENT) doc: any,
   ) {}
 
   public batches(prescribed: any, items: any, selection: any): Observable<any> {
-    const dialogRef: MatDialogRef<RxBatchViewComponent> = this.dialog.open(
+    const dialogRef: ZardDialogRef<RxBatchViewComponent> = this.dialog.create<
       RxBatchViewComponent,
-      {
-        width: '80%',
-        disableClose: false,
-      },
-    );
-    dialogRef.componentInstance.prescribed = prescribed;
-    dialogRef.componentInstance.items = items;
-    dialogRef.componentInstance.editSelection = selection;
+      unknown
+    >({
+      zContent: RxBatchViewComponent,
+      zWidth: '80%',
+      zMaskClosable: true,
+      zHideFooter: true,
+      zClosable: false,
+    });
+    dialogRef.componentInstance!.prescribed = prescribed;
+    dialogRef.componentInstance!.items = items;
+    dialogRef.componentInstance!.editSelection = selection;
 
     return dialogRef.afterClosed();
   }

--- a/src/app/app-modules/inventory/indent/indent-order-worklist/main-store-indent-order-worklist/indent-dispenses/manual-indent-dispense/manual-indent-dispense.component.ts
+++ b/src/app/app-modules/inventory/indent/indent-order-worklist/main-store-indent-order-worklist/indent-dispenses/manual-indent-dispense/manual-indent-dispense.component.ts
@@ -21,7 +21,7 @@
  */
 import { Component, OnInit, Input, DoCheck, ViewChild } from '@angular/core';
 import { FormBuilder } from '@angular/forms';
-import { MatDialog, MatDialogRef } from '@angular/material/dialog';
+import { ZardDialogService, ZardDialogRef } from 'Common-UI/v2/ui/dialog';
 import { Router, ActivatedRoute } from '@angular/router';
 import { Location, NgIf, NgFor, DatePipe } from '@angular/common';
 
@@ -92,7 +92,7 @@ export class ManualIndentDispenseComponent implements OnInit, DoCheck {
   constructor(
     private router: Router,
     private fb: FormBuilder,
-    private dialog: MatDialog,
+    private dialog: ZardDialogService,
     public http_service: LanguageService,
     private location: Location,
     private inventoryService: InventoryService,
@@ -181,18 +181,19 @@ export class ManualIndentDispenseComponent implements OnInit, DoCheck {
     editIndex: number | null,
     editableItem: any,
   ) {
-    const matDialogRef: MatDialogRef<SelectBatchForIndentItemComponent> =
-      this.dialog.open(SelectBatchForIndentItemComponent, {
-        width: '1200px',
-        height: 'auto',
-        panelClass: 'fit-screen',
-        data: {
+    const matDialogRef: ZardDialogRef<SelectBatchForIndentItemComponent> =
+      this.dialog.create<SelectBatchForIndentItemComponent, unknown>({
+        zContent: SelectBatchForIndentItemComponent,
+        zData: {
           indentItem: selectedItem,
           batchList: batchlist,
           editIndex: editIndex,
           editableItem: editableItem,
         },
-        disableClose: false,
+        zWidth: '1200px',
+        zMaskClosable: true,
+        zHideFooter: true,
+        zClosable: false,
       });
     // matDialogRef.afterClosed().subscribe((result) => {
     //   if (result) {

--- a/src/app/app-modules/inventory/indent/indent-order-worklist/main-store-indent-order-worklist/indent-dispenses/manual-indent-dispense/select-batch-for-indent-item/select-batch-for-indent-item.component.ts
+++ b/src/app/app-modules/inventory/indent/indent-order-worklist/main-store-indent-order-worklist/indent-dispenses/manual-indent-dispense/select-batch-for-indent-item/select-batch-for-indent-item.component.ts
@@ -20,7 +20,7 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 import { Component, OnInit, Inject, DoCheck } from '@angular/core';
-import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { ZardDialogRef, Z_MODAL_DATA } from 'Common-UI/v2/ui/dialog';
 import {
   FormBuilder,
   FormGroup,
@@ -85,8 +85,8 @@ export class SelectBatchForIndentItemComponent implements OnInit, DoCheck {
 
   constructor(
     private confirmationService: ConfirmationService,
-    @Inject(MAT_DIALOG_DATA) public data: any,
-    public mdDialogRef: MatDialogRef<SelectBatchForIndentItemComponent>,
+    @Inject(Z_MODAL_DATA) public data: any,
+    public mdDialogRef: ZardDialogRef<SelectBatchForIndentItemComponent>,
     private fb: FormBuilder,
     public http_service: LanguageService,
     private inventoryService: InventoryService,

--- a/src/app/app-modules/inventory/indent/indent-order-worklist/main-store-indent-order-worklist/indent-dispenses/system-indent-dispense/show-indent-batch-details/show-indent-batch-details.component.ts
+++ b/src/app/app-modules/inventory/indent/indent-order-worklist/main-store-indent-order-worklist/indent-dispenses/system-indent-dispense/show-indent-batch-details/show-indent-batch-details.component.ts
@@ -20,7 +20,7 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 import { Component, OnInit, Inject, DoCheck } from '@angular/core';
-import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { ZardDialogRef, Z_MODAL_DATA } from 'Common-UI/v2/ui/dialog';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
 import { LanguageService } from 'src/app/app-modules/core/services/language.service';
 import { NgIf, NgFor, DatePipe } from '@angular/common';
@@ -57,9 +57,9 @@ export class ShowIndentBatchDetailsComponent implements OnInit, DoCheck {
     'quantity',
   ];
   constructor(
-    @Inject(MAT_DIALOG_DATA) public data: any,
+    @Inject(Z_MODAL_DATA) public data: any,
     public http_service: LanguageService,
-    public mdDialogRef: MatDialogRef<ShowIndentBatchDetailsComponent>,
+    public mdDialogRef: ZardDialogRef<ShowIndentBatchDetailsComponent>,
   ) {}
 
   ngOnInit() {

--- a/src/app/app-modules/inventory/indent/indent-order-worklist/main-store-indent-order-worklist/indent-dispenses/system-indent-dispense/system-indent-dispense.component.ts
+++ b/src/app/app-modules/inventory/indent/indent-order-worklist/main-store-indent-order-worklist/indent-dispenses/system-indent-dispense/system-indent-dispense.component.ts
@@ -20,7 +20,7 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 import { Component, DoCheck, OnInit } from '@angular/core';
-import { MatDialogRef, MatDialog } from '@angular/material/dialog';
+import { ZardDialogRef, ZardDialogService } from 'Common-UI/v2/ui/dialog';
 import { FormBuilder, FormGroup, FormControl, FormArray } from '@angular/forms';
 
 import { InventoryService } from './../../../../../shared/service/inventory.service';
@@ -84,7 +84,7 @@ export class SystemIndentDispenseComponent implements OnInit, DoCheck {
   constructor(
     private router: Router,
     private fb: FormBuilder,
-    private dialog: MatDialog,
+    private dialog: ZardDialogService,
     public http_service: LanguageService,
     private inventoryService: InventoryService,
     private confirmationService: ConfirmationService,
@@ -165,15 +165,17 @@ export class SystemIndentDispenseComponent implements OnInit, DoCheck {
   }
 
   openModalToShowBatchList(itemBatchList: any, item: any) {
-    const mdDialogRef: MatDialogRef<ShowIndentBatchDetailsComponent> =
-      this.dialog.open(ShowIndentBatchDetailsComponent, {
-        data: {
+    const mdDialogRef: ZardDialogRef<ShowIndentBatchDetailsComponent> =
+      this.dialog.create<ShowIndentBatchDetailsComponent, unknown>({
+        zContent: ShowIndentBatchDetailsComponent,
+        zData: {
           batchList: itemBatchList,
           itemDetails: item,
         },
-        width: 0.8 * window.innerWidth + 'px',
-        panelClass: 'dialog-width',
-        disableClose: false,
+        zWidth: 0.8 * window.innerWidth + 'px',
+        zMaskClosable: true,
+        zHideFooter: true,
+        zClosable: false,
       });
     mdDialogRef.afterClosed().subscribe(
       (result) => {

--- a/src/app/app-modules/inventory/indent/indent-order-worklist/main-store-indent-order-worklist/main-store-indent-order-worklist.component.ts
+++ b/src/app/app-modules/inventory/indent/indent-order-worklist/main-store-indent-order-worklist/main-store-indent-order-worklist.component.ts
@@ -22,7 +22,7 @@
 import { Component, DoCheck, OnInit, ViewChild } from '@angular/core';
 import { ConfirmationService } from 'src/app/app-modules/core/services';
 import { Router } from '@angular/router';
-import { MatDialog } from '@angular/material/dialog';
+import { ZardDialogService } from 'Common-UI/v2/ui/dialog';
 import { InventoryService } from '../../../shared/service/inventory.service';
 import { MainStoreItemModelComponent } from './main-store-item-model/main-store-item-model.component';
 import { RejectItemFromMainstoreModelComponent } from './reject-item-from-mainstore-model/reject-item-from-mainstore-model.component';
@@ -83,7 +83,7 @@ export class MainStoreIndentOrderWorklistComponent implements OnInit, DoCheck {
 
   constructor(
     private inventoryService: InventoryService,
-    private dialog: MatDialog,
+    private dialog: ZardDialogService,
     public http_service: LanguageService,
     private confirmationService: ConfirmationService,
     private router: Router,
@@ -108,13 +108,14 @@ export class MainStoreIndentOrderWorklistComponent implements OnInit, DoCheck {
   }
 
   viewItemListDetails(orderList: any) {
-    this.dialog.open(MainStoreItemModelComponent, {
-      width: '1200px',
-      height: 'auto',
-      panelClass: 'fit-screen',
-      data: {
+    this.dialog.create<MainStoreItemModelComponent, unknown>({
+      zContent: MainStoreItemModelComponent,
+      zData: {
         itemListDetails: orderList,
       },
+      zWidth: '1200px',
+      zHideFooter: true,
+      zClosable: false,
     });
   }
   viewItemListDetailsForDispense(itemData: any) {
@@ -129,13 +130,17 @@ export class MainStoreIndentOrderWorklistComponent implements OnInit, DoCheck {
     ]);
   }
   rejectIndent(rejectOrder: any) {
-    const dialogRef = this.dialog.open(RejectItemFromMainstoreModelComponent, {
-      width: '600px',
-      height: 'auto',
-      panelClass: 'fit-screen',
-      data: {
+    const dialogRef = this.dialog.create<
+      RejectItemFromMainstoreModelComponent,
+      unknown
+    >({
+      zContent: RejectItemFromMainstoreModelComponent,
+      zData: {
         rejectItem: rejectOrder,
       },
+      zWidth: '600px',
+      zHideFooter: true,
+      zClosable: false,
     });
     dialogRef.afterClosed().subscribe((result) => {
       console.log('result', result);

--- a/src/app/app-modules/inventory/indent/indent-order-worklist/main-store-indent-order-worklist/main-store-item-model/main-store-item-model.component.ts
+++ b/src/app/app-modules/inventory/indent/indent-order-worklist/main-store-indent-order-worklist/main-store-item-model/main-store-item-model.component.ts
@@ -21,7 +21,7 @@
  */
 import { Component, OnInit, Inject, DoCheck } from '@angular/core';
 import { InventoryService } from 'src/app/app-modules/inventory/shared/service/inventory.service';
-import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { Z_MODAL_DATA, ZardDialogRef } from 'Common-UI/v2/ui/dialog';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
 import { LanguageService } from 'src/app/app-modules/core/services/language.service';
 import { NgIf, NgFor } from '@angular/common';
@@ -56,8 +56,8 @@ export class MainStoreItemModelComponent implements OnInit, DoCheck {
   displayedColumns = ['index', 'itemName', 'requiredQuantity', 'remarks'];
 
   constructor(
-    @Inject(MAT_DIALOG_DATA) public input: any,
-    public dialogRef: MatDialogRef<MainStoreItemModelComponent>,
+    @Inject(Z_MODAL_DATA) public input: any,
+    public dialogRef: ZardDialogRef<MainStoreItemModelComponent>,
     public http_service: LanguageService,
     private inventoryService: InventoryService,
   ) {}

--- a/src/app/app-modules/inventory/indent/indent-order-worklist/main-store-indent-order-worklist/reject-item-from-mainstore-model/reject-item-from-mainstore-model.component.ts
+++ b/src/app/app-modules/inventory/indent/indent-order-worklist/main-store-indent-order-worklist/reject-item-from-mainstore-model/reject-item-from-mainstore-model.component.ts
@@ -30,7 +30,7 @@ import {
   ReactiveFormsModule,
 } from '@angular/forms';
 import { ConfirmationService } from 'src/app/app-modules/core/services';
-import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { Z_MODAL_DATA, ZardDialogRef } from 'Common-UI/v2/ui/dialog';
 import { InventoryService } from 'src/app/app-modules/inventory/shared/service/inventory.service';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
 import { LanguageService } from 'src/app/app-modules/core/services/language.service';
@@ -65,8 +65,8 @@ export class RejectItemFromMainstoreModelComponent implements OnInit, DoCheck {
   currentLanguageSet: any;
 
   constructor(
-    @Inject(MAT_DIALOG_DATA) public input: any,
-    public dialogRef: MatDialogRef<RejectItemFromMainstoreModelComponent>,
+    @Inject(Z_MODAL_DATA) public input: any,
+    public dialogRef: ZardDialogRef<RejectItemFromMainstoreModelComponent>,
     public http_service: LanguageService,
     private inventoryService: InventoryService,
     private confirmationService: ConfirmationService,

--- a/src/app/app-modules/inventory/indent/indent-order-worklist/sub-store-indent-order-worklist/sub-store-indent-order-worklist.component.ts
+++ b/src/app/app-modules/inventory/indent/indent-order-worklist/sub-store-indent-order-worklist/sub-store-indent-order-worklist.component.ts
@@ -22,7 +22,7 @@
 import { Component, DoCheck, OnInit, ViewChild } from '@angular/core';
 import { Router } from '@angular/router';
 import { ConfirmationService } from 'src/app/app-modules/core/services';
-import { MatDialog } from '@angular/material/dialog';
+import { ZardDialogService } from 'Common-UI/v2/ui/dialog';
 import { SubStoreItemModelComponent } from './sub-store-item-model/sub-store-item-model.component';
 import { InventoryService } from '../../../shared/service/inventory.service';
 import { DataStorageService } from '../../../shared/service/data-storage.service';
@@ -75,7 +75,7 @@ export class SubStoreIndentOrderWorklistComponent implements OnInit, DoCheck {
   ];
   constructor(
     private inventoryService: InventoryService,
-    private dialog: MatDialog,
+    private dialog: ZardDialogService,
     public http_service: LanguageService,
     private router: Router,
     private confirmationService: ConfirmationService,
@@ -117,13 +117,14 @@ export class SubStoreIndentOrderWorklistComponent implements OnInit, DoCheck {
   }
 
   viewItemListDetails(orderlist: any) {
-    this.dialog.open(SubStoreItemModelComponent, {
-      width: '1200px',
-      height: 'auto',
-      panelClass: 'fit-screen',
-      data: {
+    this.dialog.create<SubStoreItemModelComponent, unknown>({
+      zContent: SubStoreItemModelComponent,
+      zData: {
         itemListDetails: orderlist,
       },
+      zWidth: '1200px',
+      zHideFooter: true,
+      zClosable: false,
     });
   }
   routeToRaiseRequest() {

--- a/src/app/app-modules/inventory/indent/indent-order-worklist/sub-store-indent-order-worklist/sub-store-item-model/sub-store-item-model.component.ts
+++ b/src/app/app-modules/inventory/indent/indent-order-worklist/sub-store-indent-order-worklist/sub-store-item-model/sub-store-item-model.component.ts
@@ -21,7 +21,7 @@
  */
 import { Component, OnInit, Inject, DoCheck } from '@angular/core';
 import { InventoryService } from 'src/app/app-modules/inventory/shared/service/inventory.service';
-import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { Z_MODAL_DATA, ZardDialogRef } from 'Common-UI/v2/ui/dialog';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
 import { LanguageService } from 'src/app/app-modules/core/services/language.service';
 import { NgIf, NgFor } from '@angular/common';
@@ -60,9 +60,9 @@ export class SubStoreItemModelComponent implements OnInit, DoCheck {
   ];
 
   constructor(
-    @Inject(MAT_DIALOG_DATA) public input: any,
+    @Inject(Z_MODAL_DATA) public input: any,
     public http_service: LanguageService,
-    public dialogRef: MatDialogRef<SubStoreItemModelComponent>,
+    public dialogRef: ZardDialogRef<SubStoreItemModelComponent>,
     private inventoryService: InventoryService,
   ) {}
 

--- a/src/app/app-modules/inventory/medicine-dispense/manual-medicine-dispense/manual-medicine-dispense.component.ts
+++ b/src/app/app-modules/inventory/medicine-dispense/manual-medicine-dispense/manual-medicine-dispense.component.ts
@@ -42,7 +42,7 @@ import { DataStorageService } from './../../shared/service/data-storage.service'
 import { Router } from '@angular/router';
 import * as moment from 'moment';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
-import { MatDialog, MatDialogRef } from '@angular/material/dialog';
+import { ZardDialogService, ZardDialogRef } from 'Common-UI/v2/ui/dialog';
 import { LanguageService } from 'src/app/app-modules/core/services/language.service';
 import { MatTableDataSource } from '@angular/material/table';
 import { MatPaginator } from '@angular/material/paginator';
@@ -109,7 +109,7 @@ export class ManualMedicineDispenseComponent implements OnInit, DoCheck {
 
   constructor(
     private fb: FormBuilder,
-    private dialog: MatDialog,
+    private dialog: ZardDialogService,
     private router: Router,
     public http_service: LanguageService,
     private confirmationService: ConfirmationService,
@@ -220,20 +220,21 @@ export class ManualMedicineDispenseComponent implements OnInit, DoCheck {
   openModalTOSelectBatch(editIndex: any, formValue: any, itemBatchList: any) {
     console.log('formValue', formValue);
     this.inventoryService.dialogClosed();
-    const mdDialogRef: MatDialogRef<SelectBatchComponent> = this.dialog.open(
+    const mdDialogRef: ZardDialogRef<SelectBatchComponent> = this.dialog.create<
       SelectBatchComponent,
-      {
-        data: {
-          batchList: itemBatchList,
-          editBatch: formValue,
-          editIndex: editIndex,
-        },
-        width: '1200px',
-        height: 'auto',
-        panelClass: 'fit-screen',
-        disableClose: false,
+      unknown
+    >({
+      zContent: SelectBatchComponent,
+      zData: {
+        batchList: itemBatchList,
+        editBatch: formValue,
+        editIndex: editIndex,
       },
-    );
+      zWidth: '1200px',
+      zMaskClosable: true,
+      zHideFooter: true,
+      zClosable: false,
+    });
     mdDialogRef.afterClosed().subscribe((result: any) => {
       if (result) {
         console.log("result['batchList']", result.value['batchList']);

--- a/src/app/app-modules/inventory/medicine-dispense/manual-medicine-dispense/select-batch/select-batch.component.ts
+++ b/src/app/app-modules/inventory/medicine-dispense/manual-medicine-dispense/select-batch/select-batch.component.ts
@@ -27,7 +27,7 @@ import {
   ReactiveFormsModule,
 } from '@angular/forms';
 import { ConfirmationService } from '../../../../core/services/confirmation.service';
-import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { Z_MODAL_DATA, ZardDialogRef } from 'Common-UI/v2/ui/dialog';
 import { LanguageService } from 'src/app/app-modules/core/services/language.service';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
 import { MatTableDataSource } from '@angular/material/table';
@@ -80,10 +80,10 @@ export class SelectBatchComponent implements OnInit, DoCheck {
 
   constructor(
     private confirmationService: ConfirmationService,
-    @Inject(MAT_DIALOG_DATA) public data: any,
+    @Inject(Z_MODAL_DATA) public data: any,
     private fb: FormBuilder,
     public http_service: LanguageService,
-    public mdDialogRef: MatDialogRef<SelectBatchComponent>,
+    public mdDialogRef: ZardDialogRef<SelectBatchComponent>,
   ) {}
   dataSource = new MatTableDataSource<any>();
   title!: string;

--- a/src/app/app-modules/inventory/medicine-dispense/medicine-dispense.component.ts
+++ b/src/app/app-modules/inventory/medicine-dispense/medicine-dispense.component.ts
@@ -30,7 +30,7 @@ import { InventoryService } from './../shared/service/inventory.service';
 import { ConfirmationService } from './../../core/services/confirmation.service';
 import { SetLanguageComponent } from '../../core/components/set-language.component';
 import { LanguageService } from '../../core/services/language.service';
-import { MatDialog, MatDialogRef } from '@angular/material/dialog';
+import { ZardDialogService, ZardDialogRef } from 'Common-UI/v2/ui/dialog';
 import { SearchComponent } from '../../core/components/search/search.component';
 import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 import { RouterLink } from '@angular/router';
@@ -85,7 +85,7 @@ export class MedicineDispenseComponent implements OnInit, OnDestroy, DoCheck {
     private confirmationService: ConfirmationService,
     private inventoryService: InventoryService,
     public http_service: LanguageService,
-    private dialog: MatDialog,
+    private dialog: ZardDialogService,
     readonly sessionstorage: SessionStorageService,
   ) {}
 
@@ -232,15 +232,16 @@ export class MedicineDispenseComponent implements OnInit, OnDestroy, DoCheck {
     // 720088175112
   }
   openSearchDialog() {
-    const matDialogRef: MatDialogRef<SearchComponent> = this.dialog.open(
+    const matDialogRef: ZardDialogRef<SearchComponent> = this.dialog.create<
       SearchComponent,
-      {
-        width: '1200px',
-        height: 'auto',
-        panelClass: 'fit-screen',
-        disableClose: false,
-      },
-    );
+      unknown
+    >({
+      zContent: SearchComponent,
+      zWidth: '1200px',
+      zMaskClosable: true,
+      zHideFooter: true,
+      zClosable: false,
+    });
 
     matDialogRef.afterClosed().subscribe((result) => {
       if (result) {

--- a/src/app/app-modules/inventory/medicine-dispense/system-medicine-dispense/show-batch-item/show-batch-item.component.ts
+++ b/src/app/app-modules/inventory/medicine-dispense/system-medicine-dispense/show-batch-item/show-batch-item.component.ts
@@ -23,7 +23,7 @@ import { Component, OnInit, Inject, DoCheck } from '@angular/core';
 import { InventoryService } from './../../../shared/service/inventory.service';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
 import { LanguageService } from 'src/app/app-modules/core/services/language.service';
-import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { Z_MODAL_DATA, ZardDialogRef } from 'Common-UI/v2/ui/dialog';
 import { MatTableDataSource } from '@angular/material/table';
 import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 import { NgFor, NgIf, DatePipe } from '@angular/common';
@@ -53,8 +53,8 @@ export class ShowBatchItemComponent implements OnInit, DoCheck {
   constructor(
     private inventoryService: InventoryService,
     public http_service: LanguageService,
-    @Inject(MAT_DIALOG_DATA) public data: any,
-    public mdDialogRef: MatDialogRef<ShowBatchItemComponent>,
+    @Inject(Z_MODAL_DATA) public data: any,
+    public mdDialogRef: ZardDialogRef<ShowBatchItemComponent>,
     readonly sessionstorage: SessionStorageService,
   ) {}
   issuedBatchList = new MatTableDataSource<any>();

--- a/src/app/app-modules/inventory/medicine-dispense/system-medicine-dispense/system-medicine-dispense.component.ts
+++ b/src/app/app-modules/inventory/medicine-dispense/system-medicine-dispense/system-medicine-dispense.component.ts
@@ -42,7 +42,7 @@ import * as moment from 'moment';
 import { Router } from '@angular/router';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
 import { LanguageService } from 'src/app/app-modules/core/services/language.service';
-import { MatDialog, MatDialogRef } from '@angular/material/dialog';
+import { ZardDialogService, ZardDialogRef } from 'Common-UI/v2/ui/dialog';
 import { MatTableDataSource } from '@angular/material/table';
 import { StringValidatorDirective } from '../../../core/directives/stringValidator.directive';
 import { ItemDispenseDirective } from '../../../core/directives/item-dispense.directive';
@@ -100,7 +100,7 @@ export class SystemMedicineDispenseComponent implements OnInit, DoCheck {
     private dataStorageService: DataStorageService,
     private router: Router,
     public http_service: LanguageService,
-    private dialog: MatDialog,
+    private dialog: ZardDialogService,
     private fb: FormBuilder,
   ) {}
   dataSource = new MatTableDataSource<any>();
@@ -231,18 +231,18 @@ export class SystemMedicineDispenseComponent implements OnInit, DoCheck {
   }
 
   openModalToShowBatchList(itemBatchList: any) {
-    const matDialogRef: MatDialogRef<ShowBatchItemComponent> = this.dialog.open(
-      ShowBatchItemComponent,
-      {
-        data: {
+    const matDialogRef: ZardDialogRef<ShowBatchItemComponent> =
+      this.dialog.create<ShowBatchItemComponent, unknown>({
+        zContent: ShowBatchItemComponent,
+        zData: {
           batchList: itemBatchList,
           beneficaryDetail: this.beneficaryDetail,
         },
-        width: 0.8 * window.innerWidth + 'px',
-        panelClass: 'dialog-width',
-        disableClose: false,
-      },
-    );
+        zWidth: 0.8 * window.innerWidth + 'px',
+        zMaskClosable: true,
+        zHideFooter: true,
+        zClosable: false,
+      });
     matDialogRef.afterClosed().subscribe(
       (result) => {
         console.log('result', result);

--- a/src/app/app-modules/inventory/medicine-dispense/view-medicine-dispense/view-medicine-dispense-details/view-medicine-dispense-details.component.ts
+++ b/src/app/app-modules/inventory/medicine-dispense/view-medicine-dispense/view-medicine-dispense-details/view-medicine-dispense-details.component.ts
@@ -27,7 +27,7 @@ import {
   DoCheck,
   ViewChild,
 } from '@angular/core';
-import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { Z_MODAL_DATA, ZardDialogRef } from 'Common-UI/v2/ui/dialog';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatTableDataSource } from '@angular/material/table';
 import * as moment from 'moment';
@@ -85,10 +85,10 @@ export class ViewMedicineDispenseDetailsComponent
   itemListColumns: string[] = ['itemName', 'batchNo', 'expiryDate', 'quantity'];
 
   constructor(
-    public dialogRef: MatDialogRef<ViewMedicineDispenseDetailsComponent>,
+    public dialogRef: ZardDialogRef<ViewMedicineDispenseDetailsComponent>,
     public http_service: LanguageService,
     readonly sessionstorage: SessionStorageService,
-    @Inject(MAT_DIALOG_DATA) public data: any,
+    @Inject(Z_MODAL_DATA) public data: any,
   ) {}
 
   ngOnInit() {

--- a/src/app/app-modules/inventory/medicine-dispense/view-medicine-dispense/view-medicine-dispense.component.ts
+++ b/src/app/app-modules/inventory/medicine-dispense/view-medicine-dispense/view-medicine-dispense.component.ts
@@ -26,7 +26,7 @@ import { InventoryService } from '../../shared/service/inventory.service';
 import { DataStorageService } from './../../shared/service/data-storage.service';
 import { Router } from '@angular/router';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
-import { MatDialog, MatDialogRef } from '@angular/material/dialog';
+import { ZardDialogService, ZardDialogRef } from 'Common-UI/v2/ui/dialog';
 import { LanguageService } from 'src/app/app-modules/core/services/language.service';
 import { MatTableDataSource } from '@angular/material/table';
 import { MatPaginator } from '@angular/material/paginator';
@@ -83,7 +83,7 @@ export class ViewMedicineDispenseComponent implements OnInit, DoCheck {
   constructor(
     private location: Location,
     private inventoryService: InventoryService,
-    private dialog: MatDialog,
+    private dialog: ZardDialogService,
     public http_service: LanguageService,
     private router: Router,
     readonly sessionstorage: SessionStorageService,
@@ -201,13 +201,14 @@ export class ViewMedicineDispenseComponent implements OnInit, DoCheck {
 
   popOutDispense(dispense: any, dispenseResponse: any) {
     if (dispenseResponse) {
-      const mdDialogRef: MatDialogRef<ViewMedicineDispenseDetailsComponent> =
-        this.dialog.open(ViewMedicineDispenseDetailsComponent, {
-          width: '1200px',
-          height: 'auto',
-          panelClass: 'fit-screen',
-          data: { dispense: dispense, dispenseItem: dispenseResponse },
-          disableClose: false,
+      const mdDialogRef: ZardDialogRef<ViewMedicineDispenseDetailsComponent> =
+        this.dialog.create<ViewMedicineDispenseDetailsComponent, unknown>({
+          zContent: ViewMedicineDispenseDetailsComponent,
+          zData: { dispense: dispense, dispenseItem: dispenseResponse },
+          zWidth: '1200px',
+          zMaskClosable: true,
+          zHideFooter: true,
+          zClosable: false,
         });
       mdDialogRef.afterClosed().subscribe((result: any) => {
         if (result) {

--- a/src/app/app-modules/inventory/patient-return/benificiary-details/benificiary-details.component.ts
+++ b/src/app/app-modules/inventory/patient-return/benificiary-details/benificiary-details.component.ts
@@ -30,7 +30,7 @@ import {
 import { InventoryService } from './../../../inventory/shared/service/inventory.service';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
 import { LanguageService } from 'src/app/app-modules/core/services/language.service';
-import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { Z_MODAL_DATA, ZardDialogRef } from 'Common-UI/v2/ui/dialog';
 import { MatTableDataSource } from '@angular/material/table';
 import { MatPaginator } from '@angular/material/paginator';
 import { NgIf, NgFor } from '@angular/common';
@@ -73,8 +73,8 @@ export class BenificiaryDetailsComponent
   constructor(
     private inventoryService: InventoryService,
     private http_service: LanguageService,
-    public dialogRef: MatDialogRef<BenificiaryDetailsComponent>,
-    @Inject(MAT_DIALOG_DATA) public data: any,
+    public dialogRef: ZardDialogRef<BenificiaryDetailsComponent>,
+    @Inject(Z_MODAL_DATA) public data: any,
   ) {}
 
   ngOnInit() {

--- a/src/app/app-modules/inventory/patient-return/item-batch-details-for-patient-return/item-batch-details-for-patient-return.component.ts
+++ b/src/app/app-modules/inventory/patient-return/item-batch-details-for-patient-return/item-batch-details-for-patient-return.component.ts
@@ -42,7 +42,7 @@ import { ConfirmationService } from '../../../core/services/confirmation.service
 import { SearchComponent } from '../../../core/components/search/search.component';
 import { Router } from '@angular/router';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
-import { MatDialog, MatDialogRef } from '@angular/material/dialog';
+import { ZardDialogService, ZardDialogRef } from 'Common-UI/v2/ui/dialog';
 import { LanguageService } from 'src/app/app-modules/core/services/language.service';
 import { PatientReturnBatchDetailsComponent } from '../patient-return-batch-details/patient-return-batch-details.component';
 import { MatTableDataSource } from '@angular/material/table';
@@ -110,7 +110,7 @@ export class ItemBatchDetailsForPatientReturnComponent
   ];
   constructor(
     private fb: FormBuilder,
-    private dialog: MatDialog,
+    private dialog: ZardDialogService,
     private http_service: LanguageService,
     private inventoryService: InventoryService,
     private confirmationService: ConfirmationService,
@@ -176,17 +176,18 @@ export class ItemBatchDetailsForPatientReturnComponent
     console.warn(batchList);
     const itemName = formvalue.itemName;
     console.log('Itemmmmm', itemName);
-    const matDialogRef: MatDialogRef<PatientReturnBatchDetailsComponent> =
-      this.dialog.open(PatientReturnBatchDetailsComponent, {
-        width: '1200px',
-        height: 'auto',
-        panelClass: 'fit-screen',
-        data: {
+    const matDialogRef: ZardDialogRef<PatientReturnBatchDetailsComponent> =
+      this.dialog.create<PatientReturnBatchDetailsComponent, unknown>({
+        zContent: PatientReturnBatchDetailsComponent,
+        zData: {
           batchList: batchList,
           editIndex: editIndex,
           editBatch: formvalue,
         },
-        disableClose: false,
+        zWidth: '1200px',
+        zMaskClosable: true,
+        zHideFooter: true,
+        zClosable: false,
       });
     matDialogRef.afterClosed().subscribe((selectedBatchList: any) => {
       if (selectedBatchList) {
@@ -242,15 +243,16 @@ export class ItemBatchDetailsForPatientReturnComponent
     });
   }
   openSearchDialog() {
-    const mdDialogRef: MatDialogRef<SearchComponent> = this.dialog.open(
+    const mdDialogRef: ZardDialogRef<SearchComponent> = this.dialog.create<
       SearchComponent,
-      {
-        width: '1200px',
-        height: 'auto',
-        panelClass: 'fit-screen',
-        disableClose: false,
-      },
-    );
+      unknown
+    >({
+      zContent: SearchComponent,
+      zWidth: '1200px',
+      zMaskClosable: true,
+      zHideFooter: true,
+      zClosable: false,
+    });
   }
   editItem(item: any, i: any) {
     this.getBatchDetail(item, i);

--- a/src/app/app-modules/inventory/patient-return/patient-return-batch-details/patient-return-batch-details.component.ts
+++ b/src/app/app-modules/inventory/patient-return/patient-return-batch-details/patient-return-batch-details.component.ts
@@ -31,7 +31,7 @@ import {
 import { InventoryService } from './../../../inventory/shared/service/inventory.service';
 import { ConfirmationService } from './../../../core/services/confirmation.service';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
-import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { Z_MODAL_DATA, ZardDialogRef } from 'Common-UI/v2/ui/dialog';
 import { LanguageService } from 'src/app/app-modules/core/services/language.service';
 import { MatTableDataSource } from '@angular/material/table';
 import { NgFor, NgIf, DatePipe } from '@angular/common';
@@ -80,8 +80,8 @@ export class PatientReturnBatchDetailsComponent implements OnInit, DoCheck {
   dataSource = new MatTableDataSource<any>();
 
   constructor(
-    public dialogRef: MatDialogRef<PatientReturnBatchDetailsComponent>,
-    @Inject(MAT_DIALOG_DATA) public data: any,
+    public dialogRef: ZardDialogRef<PatientReturnBatchDetailsComponent>,
+    @Inject(Z_MODAL_DATA) public data: any,
     private formBuilder: FormBuilder,
     private http_service: LanguageService,
     private inventoryService: InventoryService,

--- a/src/app/app-modules/inventory/patient-return/patient-return-previous-record/patient-return-previous-record.component.ts
+++ b/src/app/app-modules/inventory/patient-return/patient-return-previous-record/patient-return-previous-record.component.ts
@@ -25,7 +25,7 @@ import { DataStorageService } from '../../shared/service/data-storage.service';
 import { InventoryService } from '../../shared/service/inventory.service';
 import { Location, NgIf } from '@angular/common';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
-import { MatDialog } from '@angular/material/dialog';
+import { ZardDialogService } from 'Common-UI/v2/ui/dialog';
 import { LanguageService } from 'src/app/app-modules/core/services/language.service';
 import { MatTableDataSource } from '@angular/material/table';
 import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
@@ -76,7 +76,7 @@ export class PatientReturnPreviousRecordComponent implements OnInit, DoCheck {
 
   constructor(
     private location: Location,
-    private dialog: MatDialog,
+    private dialog: ZardDialogService,
     private router: Router,
     private http_service: LanguageService,
     private dataStorageService: DataStorageService,

--- a/src/app/app-modules/inventory/patient-return/patient-return.component.ts
+++ b/src/app/app-modules/inventory/patient-return/patient-return.component.ts
@@ -29,7 +29,7 @@ import {
 import { InventoryService } from './../../inventory/shared/service/inventory.service';
 import { ConfirmationService } from './../../core/services/confirmation.service';
 import { SetLanguageComponent } from '../../core/components/set-language.component';
-import { MatDialog, MatDialogRef } from '@angular/material/dialog';
+import { ZardDialogService, ZardDialogRef } from 'Common-UI/v2/ui/dialog';
 import { LanguageService } from '../../core/services/language.service';
 import { BenificiaryDetailsComponent } from './benificiary-details/benificiary-details.component';
 import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
@@ -74,7 +74,7 @@ export class PatientReturnComponent implements OnInit, DoCheck {
 
   constructor(
     private fb: FormBuilder,
-    private dialog: MatDialog,
+    private dialog: ZardDialogService,
     private http_service: LanguageService,
     private inventoryService: InventoryService,
     readonly sessionstorage: SessionStorageService,
@@ -140,15 +140,16 @@ export class PatientReturnComponent implements OnInit, DoCheck {
   }
 
   openBenDetailsModal() {
-    const mdDialogRef: MatDialogRef<BenificiaryDetailsComponent> =
-      this.dialog.open(BenificiaryDetailsComponent, {
-        width: '1200px',
-        height: 'auto',
-        panelClass: 'fit-screen',
-        data: {
+    const mdDialogRef: ZardDialogRef<BenificiaryDetailsComponent> =
+      this.dialog.create<BenificiaryDetailsComponent, unknown>({
+        zContent: BenificiaryDetailsComponent,
+        zData: {
           beneficiaryDetailsList: this.beneficiaryDetailsList,
         },
-        disableClose: false,
+        zWidth: '1200px',
+        zMaskClosable: true,
+        zHideFooter: true,
+        zClosable: false,
       });
     mdDialogRef.afterClosed().subscribe((benificiary) => {
       if (benificiary) {

--- a/src/app/app-modules/inventory/physical-stock-entry/view-physical-stock/view-physical-stock-details/view-physical-stock-details.component.ts
+++ b/src/app/app-modules/inventory/physical-stock-entry/view-physical-stock/view-physical-stock-details/view-physical-stock-details.component.ts
@@ -28,7 +28,7 @@ import {
   ViewChild,
   AfterViewInit,
 } from '@angular/core';
-import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { Z_MODAL_DATA, ZardDialogRef } from 'Common-UI/v2/ui/dialog';
 import { MatPaginator } from '@angular/material/paginator';
 
 import { MatTableDataSource } from '@angular/material/table';
@@ -76,8 +76,8 @@ export class ViewPhysicalStockDetailsComponent
 
   constructor(
     private http_service: LanguageService,
-    public dialogRef: MatDialogRef<ViewPhysicalStockDetailsComponent>,
-    @Inject(MAT_DIALOG_DATA) public data: any,
+    public dialogRef: ZardDialogRef<ViewPhysicalStockDetailsComponent>,
+    @Inject(Z_MODAL_DATA) public data: any,
   ) {}
 
   ngOnInit() {

--- a/src/app/app-modules/inventory/physical-stock-entry/view-physical-stock/view-physical-stock.component.ts
+++ b/src/app/app-modules/inventory/physical-stock-entry/view-physical-stock/view-physical-stock.component.ts
@@ -28,7 +28,7 @@ import * as moment from 'moment';
 import { Router } from '@angular/router';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
 import { LanguageService } from 'src/app/app-modules/core/services/language.service';
-import { MatDialog, MatDialogRef } from '@angular/material/dialog';
+import { ZardDialogService, ZardDialogRef } from 'Common-UI/v2/ui/dialog';
 import { MatTableDataSource } from '@angular/material/table';
 import { MatPaginator } from '@angular/material/paginator';
 import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
@@ -95,7 +95,7 @@ export class ViewPhysicalStockComponent implements OnInit, DoCheck {
     private inventoryService: InventoryService,
     private dataStorageService: DataStorageService,
     readonly sessionstorage: SessionStorageService,
-    private dialog: MatDialog,
+    private dialog: ZardDialogService,
     private router: Router,
   ) {}
 
@@ -202,13 +202,14 @@ export class ViewPhysicalStockComponent implements OnInit, DoCheck {
   popOutEntryDetails(entry: any, stockEntryResponse: any) {
     console.warn(entry, stockEntryResponse);
     if (stockEntryResponse) {
-      const matDialogRef: MatDialogRef<ViewPhysicalStockDetailsComponent> =
-        this.dialog.open(ViewPhysicalStockDetailsComponent, {
-          width: '1200px',
-          height: 'auto',
-          panelClass: 'fit-screen',
-          data: { stockEntry: entry, entryDetails: stockEntryResponse },
-          disableClose: false,
+      const matDialogRef: ZardDialogRef<ViewPhysicalStockDetailsComponent> =
+        this.dialog.create<ViewPhysicalStockDetailsComponent, unknown>({
+          zContent: ViewPhysicalStockDetailsComponent,
+          zData: { stockEntry: entry, entryDetails: stockEntryResponse },
+          zWidth: '1200px',
+          zMaskClosable: true,
+          zHideFooter: true,
+          zClosable: false,
         });
       matDialogRef.afterClosed().subscribe((result) => {
         if (result) {

--- a/src/app/app-modules/inventory/store-self-consumption/view-store-self-consumption/view-store-self-consumption-details/view-store-self-consumption-details.component.ts
+++ b/src/app/app-modules/inventory/store-self-consumption/view-store-self-consumption/view-store-self-consumption-details/view-store-self-consumption-details.component.ts
@@ -28,7 +28,7 @@ import {
   ViewChild,
   AfterViewInit,
 } from '@angular/core';
-import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { Z_MODAL_DATA, ZardDialogRef } from 'Common-UI/v2/ui/dialog';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatTableDataSource } from '@angular/material/table';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
@@ -89,8 +89,8 @@ export class ViewStoreSelfConsumptionDetailsComponent
 
   constructor(
     private http_service: LanguageService,
-    public dialogRef: MatDialogRef<ViewStoreSelfConsumptionDetailsComponent>,
-    @Inject(MAT_DIALOG_DATA) public data: any,
+    public dialogRef: ZardDialogRef<ViewStoreSelfConsumptionDetailsComponent>,
+    @Inject(Z_MODAL_DATA) public data: any,
   ) {}
 
   ngOnInit() {

--- a/src/app/app-modules/inventory/store-self-consumption/view-store-self-consumption/view-store-self-consumption.component.ts
+++ b/src/app/app-modules/inventory/store-self-consumption/view-store-self-consumption/view-store-self-consumption.component.ts
@@ -27,7 +27,7 @@ import * as moment from 'moment';
 import { Router } from '@angular/router';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
 import { LanguageService } from 'src/app/app-modules/core/services/language.service';
-import { MatDialog, MatDialogRef } from '@angular/material/dialog';
+import { ZardDialogService, ZardDialogRef } from 'Common-UI/v2/ui/dialog';
 import { ViewStoreSelfConsumptionDetailsComponent } from './view-store-self-consumption-details/view-store-self-consumption-details.component';
 import { MatTableDataSource } from '@angular/material/table';
 import { MatPaginator } from '@angular/material/paginator';
@@ -93,7 +93,7 @@ export class ViewStoreSelfConsumptionComponent implements OnInit, DoCheck {
     private inventoryService: InventoryService,
     private dataStorageService: DataStorageService,
     private http_service: LanguageService,
-    private dialog: MatDialog,
+    private dialog: ZardDialogService,
     private router: Router,
     readonly sessionstorage: SessionStorageService,
   ) {}
@@ -209,16 +209,17 @@ export class ViewStoreSelfConsumptionComponent implements OnInit, DoCheck {
 
   popOutConsumption(consumptionDetails: any, consumptionResponse: any) {
     if (consumptionResponse) {
-      const mdDialogRef: MatDialogRef<ViewStoreSelfConsumptionDetailsComponent> =
-        this.dialog.open(ViewStoreSelfConsumptionDetailsComponent, {
-          width: '1200px',
-          height: 'auto',
-          panelClass: 'fit-screen',
-          data: {
+      const mdDialogRef: ZardDialogRef<ViewStoreSelfConsumptionDetailsComponent> =
+        this.dialog.create<ViewStoreSelfConsumptionDetailsComponent, unknown>({
+          zContent: ViewStoreSelfConsumptionDetailsComponent,
+          zData: {
             consumptionDetails: consumptionDetails,
             consumptionItem: consumptionResponse,
           },
-          disableClose: false,
+          zWidth: '1200px',
+          zMaskClosable: true,
+          zHideFooter: true,
+          zClosable: false,
         });
       mdDialogRef.afterClosed().subscribe((result) => {
         if (result) {

--- a/src/app/app-modules/inventory/store-stock-adjustment/view-stock-adjustment-details/view-stock-adjustment-details.component.ts
+++ b/src/app/app-modules/inventory/store-stock-adjustment/view-stock-adjustment-details/view-stock-adjustment-details.component.ts
@@ -20,7 +20,7 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 import { Component, OnInit, Inject, DoCheck, ViewChild } from '@angular/core';
-import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { Z_MODAL_DATA, ZardDialogRef } from 'Common-UI/v2/ui/dialog';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
 import { LanguageService } from 'src/app/app-modules/core/services/language.service';
 import { InventoryService } from '../../shared/service/inventory.service';
@@ -84,8 +84,8 @@ export class ViewStockAdjustmentDetailsComponent implements OnInit, DoCheck {
 
   constructor(
     private http_service: LanguageService,
-    @Inject(MAT_DIALOG_DATA) public input: any,
-    public dialogRef: MatDialogRef<ViewStockAdjustmentDetailsComponent>,
+    @Inject(Z_MODAL_DATA) public input: any,
+    public dialogRef: ZardDialogRef<ViewStockAdjustmentDetailsComponent>,
     private inventoryService: InventoryService,
   ) {}
 

--- a/src/app/app-modules/inventory/store-stock-adjustment/view-stock-adjustment-draft-details/view-stock-adjustment-draft-details.component.ts
+++ b/src/app/app-modules/inventory/store-stock-adjustment/view-stock-adjustment-draft-details/view-stock-adjustment-draft-details.component.ts
@@ -20,7 +20,7 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 import { Component, OnInit, Inject, DoCheck, ViewChild } from '@angular/core';
-import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { Z_MODAL_DATA, ZardDialogRef } from 'Common-UI/v2/ui/dialog';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
 import { LanguageService } from 'src/app/app-modules/core/services/language.service';
 import { InventoryService } from '../../shared/service/inventory.service';
@@ -85,8 +85,8 @@ export class ViewStockAdjustmentDraftDetailsComponent
 
   constructor(
     private http_service: LanguageService,
-    @Inject(MAT_DIALOG_DATA) public input: any,
-    public dialogRef: MatDialogRef<ViewStockAdjustmentDraftDetailsComponent>,
+    @Inject(Z_MODAL_DATA) public input: any,
+    public dialogRef: ZardDialogRef<ViewStockAdjustmentDraftDetailsComponent>,
     private inventoryService: InventoryService,
   ) {}
 

--- a/src/app/app-modules/inventory/store-stock-adjustment/view-store-stock-adjustment-draft/view-store-stock-adjustment-draft.component.ts
+++ b/src/app/app-modules/inventory/store-stock-adjustment/view-store-stock-adjustment-draft/view-store-stock-adjustment-draft.component.ts
@@ -24,7 +24,7 @@ import { Location, NgFor, NgIf } from '@angular/common';
 import { Router } from '@angular/router';
 import * as moment from 'moment';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
-import { MatDialog } from '@angular/material/dialog';
+import { ZardDialogService } from 'Common-UI/v2/ui/dialog';
 import { LanguageService } from 'src/app/app-modules/core/services/language.service';
 import { DataStorageService } from '../../shared/service/data-storage.service';
 import { InventoryService } from '../../shared/service/inventory.service';
@@ -90,7 +90,7 @@ export class ViewStoreStockAdjustmentDraftComponent implements OnInit, DoCheck {
   constructor(
     private location: Location,
     private router: Router,
-    private dialog: MatDialog,
+    private dialog: ZardDialogService,
     private http_service: LanguageService,
     private dataStorageService: DataStorageService,
     private inventoryService: InventoryService,
@@ -182,13 +182,14 @@ export class ViewStoreStockAdjustmentDraftComponent implements OnInit, DoCheck {
 
   viewStockAdjustmentDraftDetails(draftID: any) {
     this.dialog
-      .open(ViewStockAdjustmentDraftDetailsComponent, {
-        width: '1200px',
-        height: 'auto',
-        panelClass: 'fit-screen',
-        data: {
+      .create<ViewStockAdjustmentDraftDetailsComponent, unknown>({
+        zContent: ViewStockAdjustmentDraftDetailsComponent,
+        zData: {
           adjustmentID: draftID,
         },
+        zWidth: '1200px',
+        zHideFooter: true,
+        zClosable: false,
       })
       .afterClosed()
       .subscribe((response) => {

--- a/src/app/app-modules/inventory/store-stock-adjustment/view-store-stock-adjustment/view-store-stock-adjustment.component.ts
+++ b/src/app/app-modules/inventory/store-stock-adjustment/view-store-stock-adjustment/view-store-stock-adjustment.component.ts
@@ -24,7 +24,7 @@ import { Location, NgFor, NgIf } from '@angular/common';
 import { Router } from '@angular/router';
 import * as moment from 'moment';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
-import { MatDialog } from '@angular/material/dialog';
+import { ZardDialogService } from 'Common-UI/v2/ui/dialog';
 import { LanguageService } from 'src/app/app-modules/core/services/language.service';
 import { DataStorageService } from '../../shared/service/data-storage.service';
 import { ViewStockAdjustmentDetailsComponent } from '../view-stock-adjustment-details/view-stock-adjustment-details.component';
@@ -88,7 +88,7 @@ export class ViewStoreStockAdjustmentComponent implements OnInit, DoCheck {
 
   constructor(
     private location: Location,
-    private dialog: MatDialog,
+    private dialog: ZardDialogService,
     private http_service: LanguageService,
     private router: Router,
     private dataStorageService: DataStorageService,
@@ -188,13 +188,14 @@ export class ViewStoreStockAdjustmentComponent implements OnInit, DoCheck {
 
   viewStockAdjustmentDetails(adjustmentID: any) {
     this.dialog
-      .open(ViewStockAdjustmentDetailsComponent, {
-        width: '1200px',
-        height: 'auto',
-        panelClass: 'fit-screen',
-        data: {
+      .create<ViewStockAdjustmentDetailsComponent, unknown>({
+        zContent: ViewStockAdjustmentDetailsComponent,
+        zData: {
           adjustmentID: adjustmentID,
         },
+        zWidth: '1200px',
+        zHideFooter: true,
+        zClosable: false,
       })
       .afterClosed()
       .subscribe((response) => {

--- a/src/app/app-modules/inventory/store-stock-transfer/view-store-stock-transfer/view-store-stock-transfer-details/view-store-stock-transfer-details.component.ts
+++ b/src/app/app-modules/inventory/store-stock-transfer/view-store-stock-transfer/view-store-stock-transfer-details/view-store-stock-transfer-details.component.ts
@@ -28,7 +28,7 @@ import {
   ViewChild,
   AfterViewInit,
 } from '@angular/core';
-import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { Z_MODAL_DATA, ZardDialogRef } from 'Common-UI/v2/ui/dialog';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatTableDataSource } from '@angular/material/table';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
@@ -75,8 +75,8 @@ export class ViewStoreStockTransferDetailsComponent
 
   constructor(
     private http_service: LanguageService,
-    public dialogRef: MatDialogRef<ViewStoreStockTransferDetailsComponent>,
-    @Inject(MAT_DIALOG_DATA) public data: any,
+    public dialogRef: ZardDialogRef<ViewStoreStockTransferDetailsComponent>,
+    @Inject(Z_MODAL_DATA) public data: any,
   ) {}
 
   ngOnInit() {

--- a/src/app/app-modules/inventory/store-stock-transfer/view-store-stock-transfer/view-store-stock-transfer.component.ts
+++ b/src/app/app-modules/inventory/store-stock-transfer/view-store-stock-transfer/view-store-stock-transfer.component.ts
@@ -27,7 +27,7 @@ import { DataStorageService } from './../../shared/service/data-storage.service'
 import * as moment from 'moment';
 import { Router } from '@angular/router';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
-import { MatDialog, MatDialogRef } from '@angular/material/dialog';
+import { ZardDialogService, ZardDialogRef } from 'Common-UI/v2/ui/dialog';
 import { LanguageService } from 'src/app/app-modules/core/services/language.service';
 import { MatTableDataSource } from '@angular/material/table';
 import { MatPaginator } from '@angular/material/paginator';
@@ -86,7 +86,7 @@ export class ViewStoreStockTransferComponent implements OnInit, DoCheck {
     private location: Location,
     private inventoryService: InventoryService,
     private dataStorageService: DataStorageService,
-    private dialog: MatDialog,
+    private dialog: ZardDialogService,
     private http_service: LanguageService,
     private router: Router,
     readonly sessionstorage: SessionStorageService,
@@ -220,13 +220,14 @@ export class ViewStoreStockTransferComponent implements OnInit, DoCheck {
   popOutEntryDetails(entry: any, stockEntryResponse: any) {
     console.warn(entry, stockEntryResponse);
     if (stockEntryResponse) {
-      const mdDialogRef: MatDialogRef<ViewStoreStockTransferDetailsComponent> =
-        this.dialog.open(ViewStoreStockTransferDetailsComponent, {
-          width: '1200px',
-          height: 'auto',
-          panelClass: 'fit-screen',
-          data: { stockEntry: entry, entryDetails: stockEntryResponse },
-          disableClose: false,
+      const mdDialogRef: ZardDialogRef<ViewStoreStockTransferDetailsComponent> =
+        this.dialog.create<ViewStoreStockTransferDetailsComponent, unknown>({
+          zContent: ViewStoreStockTransferDetailsComponent,
+          zData: { stockEntry: entry, entryDetails: stockEntryResponse },
+          zWidth: '1200px',
+          zMaskClosable: true,
+          zHideFooter: true,
+          zClosable: false,
         });
       mdDialogRef.afterClosed().subscribe((result) => {
         if (result) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -29,9 +29,6 @@ import {
   provideHttpClient,
   withInterceptorsFromDi,
 } from '@angular/common/http';
-import { MatDialogModule } from '@angular/material/dialog';
-import { MatDatepickerModule } from '@angular/material/datepicker';
-
 import { AppComponent } from './app/app.component';
 import { appRoutes } from './app/app.routes';
 
@@ -65,13 +62,7 @@ import { PrescribedDrugService } from './app/app-modules/rx/shared/service/presc
 
 bootstrapApplication(AppComponent, {
   providers: [
-    importProvidersFrom(
-      BrowserModule,
-      FormsModule,
-      ReactiveFormsModule,
-      MatDialogModule,
-      MatDatepickerModule,
-    ),
+    importProvidersFrom(BrowserModule, FormsModule, ReactiveFormsModule),
     provideRouter(appRoutes, withHashLocation()),
     provideHttpClient(withInterceptorsFromDi()),
     AuthenticationService,


### PR DESCRIPTION
**Stacked on #155** (core widgets). **Phase 4a**: migrates the entire dialog layer from `MatDialog` to `ZardDialogService` — the last *functional* Material usage in the app (54 files).

- **ConfirmationService** rewritten on the MMU-UI pattern (shared `createDialog` helper, `componentInstance!` config, `afterClosed()` semantics identical)
- **All 24 `open()` call sites** (17 components + 7 directives): `data→zData`, `width→zWidth`, `disableClose→zMaskClosable` + `ref.disableClose` for the session-timeout dialog (Escape blocked, as before)
- **26 dialog content components**: `MatDialogRef→ZardDialogRef`, `MAT_DIALOG_DATA→Z_MODAL_DATA`; template-facing property names unchanged
- `main.ts`: `MatDialogModule`/`MatDatepickerModule` providers removed
- The Zard dialog engine (Common-UI `306f09b`) already contains the route-scoped-provider fix, and all app services are root-provided — no NG0201 class of issues

Flagged: `height/panelClass` options dropped (Zard auto-sizes — same as MMU); `textarea-dialog`'s `backdropClick()` close-with-data subscription removed (`ZardDialogRef` has no backdropClick; the service has zero callers).

After this PR the only `@angular/material` left is `MatTableDataSource`/`MatPaginator` as data structures — removed with the dependency itself in the final Phase-4b PR.

`build-dev` ✅ · eslint/prettier ✅
