### PR TITLE
fix(dispense): make Manual "Qty to Dispense" editable again

### DIFF
--- a/src/app/app-modules/inventory/medicine-dispense/manual-medicine-dispense/select-batch/select-batch.component.html
+++ b/src/app/app-modules/inventory/medicine-dispense/manual-medicine-dispense/select-batch/select-batch.component.html
@@ -131,7 +131,6 @@
                   "
                   allowText="number"
                   [attr.maxlength]="('' + batch.value.quantityOnBatch).length"
-                  [readonly]="!batch.value.batchNo"
                   name="quantityOfDispense"
                   formControlName="quantityOfDispense"
                   (keyup)="calculateDispenseQuantity()"


### PR DESCRIPTION
## What
Restores the always-editable **"Qty to Dispense"** field in the Manual medicine-dispense batch selection.

## Why
The Material → Zard migration changed this field from `[disabled]="!batch.value.batchNo"` — a no-op on reactive-form controls, so it was **always editable** — to `[readonly]="!batch.value.batchNo"`, which the DOM **does** honour. The field became read-only until a batch was selected, blocking manual dispensing.

## Fix
Remove the `[readonly]` gate in `manual-medicine-dispense/select-batch/select-batch.component.html` → the field is editable again, matching long-standing behaviour.

## Testing
Pharmacist → Medicine Dispense → select a beneficiary → **Manual Dispense** → add an item → the **"Qty to Dispense"** field accepts input immediately, without first selecting a batch.

Fixes the MMU QA report: *"Dispensed Quantity Field is Not Editable When 'Manual Issue' is Selected in the Pharmacist Module."*